### PR TITLE
DEN-4986 [Automatic PR] Add concurrency to workflows

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,6 +2,10 @@ name: Go
 
 on: [push]
 
+concurrency:
+  group: ${{ github.workflow }}${{ github.ref_name != github.event.repository.default_branch && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
+
 jobs:
   test:
     strategy:
@@ -10,46 +14,46 @@ jobs:
         platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-    - name: Install Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: ${{ matrix.go-version }}
-    - name: Environment information
-      run: |
-        uname -a
-        go version
-        go env
-    - name: Vet
-      if: matrix.platform == 'ubuntu-latest'
-      run: go vet -v ./...
-    - name: Lint
-      if: matrix.platform == 'ubuntu-latest'
-      run: |
-        export PATH=$PATH:$(go env GOPATH)/bin
-        go install golang.org/x/lint/golint@latest
-        golint -set_exit_status ./...
-    - name: staticcheck.io
-      if: matrix.platform == 'ubuntu-latest'
-      uses: dominikh/staticcheck-action@v1.3.1
-      with:
-        install-go: false
-    - name: gofumpt formatting
-      if: matrix.platform == 'ubuntu-latest'
-      run: |
-        export PATH=$PATH:$(go env GOPATH)/bin
-        go install mvdan.cc/gofumpt@latest
-        gofumpt -d .
-        [ -z "$(gofumpt -l .)" ]
-    - name: Test with -race
-      run: go test -vet=off -race -count=1 ./...
-    - name: Test with coverage report
-      run: |
-        go test -vet=off -count=1 ./... -coverprofile cover.out
-        go tool cover -html cover.out -o cover.html
-    - name: Archive code coverage report
-      uses: actions/upload-artifact@v4
-      with:
-        name: code-coverage-report
-        path: coverage-${{ matrix.platform }}.html
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Environment information
+        run: |
+          uname -a
+          go version
+          go env
+      - name: Vet
+        if: matrix.platform == 'ubuntu-latest'
+        run: go vet -v ./...
+      - name: Lint
+        if: matrix.platform == 'ubuntu-latest'
+        run: |
+          export PATH=$PATH:$(go env GOPATH)/bin
+          go install golang.org/x/lint/golint@latest
+          golint -set_exit_status ./...
+      - name: staticcheck.io
+        if: matrix.platform == 'ubuntu-latest'
+        uses: dominikh/staticcheck-action@v1.3.1
+        with:
+          install-go: false
+      - name: gofumpt formatting
+        if: matrix.platform == 'ubuntu-latest'
+        run: |
+          export PATH=$PATH:$(go env GOPATH)/bin
+          go install mvdan.cc/gofumpt@latest
+          gofumpt -d .
+          [ -z "$(gofumpt -l .)" ]
+      - name: Test with -race
+        run: go test -vet=off -race -count=1 ./...
+      - name: Test with coverage report
+        run: |
+          go test -vet=off -count=1 ./... -coverprofile cover.out
+          go tool cover -html cover.out -o cover.html
+      - name: Archive code coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-coverage-report
+          path: coverage-${{ matrix.platform }}.html


### PR DESCRIPTION
This is an automatic PR that adds concurrency to GHA workflows. As an effect there will be at most one running job __in a concurrency group__ (a branch) at any time, default branch excluded.
Optimizations like these are good for making runners available for other jobs, and will be enforced soon.

If you don't agree with these changes leave a review and raise your concern, otherwise please __merge the PR__.
