### PR TITLE
Add support for applies-to

### DIFF
--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -129,6 +129,7 @@ type Group struct {
 	Patterns        []string `yaml:"patterns,omitempty"`
 	ExcludePatterns []string `yaml:"exclude-patterns,omitempty"`
 	UpdateTypes     []string `yaml:"update-types,omitempty"`
+	AppliesTo       string   `yaml:"applies-to,omitempty"`
 }
 
 // Registry holds the config items of a registry definition


### PR DESCRIPTION
Add support for the `applies-to` in update groups: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#:~:text=hyphens%20%2D.-,applies%2Dto,-Specify%20which%20type