### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,8 @@
 name: Go
 
+permissions:
+  contents: read
+
 on: [push]
 
 concurrency:


### PR DESCRIPTION
Potential fix for [https://github.com/getyourguide/dependabutler/security/code-scanning/1](https://github.com/getyourguide/dependabutler/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the minimal permissions required for the workflow to function correctly. Based on the workflow's steps, it primarily needs read access to the repository contents (`contents: read`). No write permissions are required for the operations described in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
