### PR TITLE
[TP-13604] Add cooldown option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The default configuration file name is `dependabutler.yml`. Use `dependabutler-s
 | repo                | ³         |                     | name of the repository to scan                |
 | repoFile            | ³         |                     | file containing repositories, one per line    |
 | stable-group-prefixes | no      | true                | ensures group names have numeric prefixes (01_, 02_, etc.) |
-| update-missing-cooldown-settings | no | true          | when true, adds missing cooldown settings to existing updates; when false, only adds cooldown to new repos/sections |
+| update-missing-cooldown-settings | no | true          | update existing manifests adding default settings |
 
 ¹ mandatory for local mode  
 ² mandatory for remote mode  

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The default configuration file name is `dependabutler.yml`. Use `dependabutler-s
 | repo                | ³         |                     | name of the repository to scan                |
 | repoFile            | ³         |                     | file containing repositories, one per line    |
 | stable-group-prefixes | no      | true                | ensures group names have numeric prefixes (01_, 02_, etc.) |
+| update-missing-cooldown-settings | no | true          | when true, adds missing cooldown settings to existing updates; when false, only adds cooldown to new repos/sections |
 
 ¹ mandatory for local mode  
 ² mandatory for remote mode  

--- a/dependabutler-sample.yml
+++ b/dependabutler-sample.yml
@@ -23,8 +23,10 @@ update-defaults:
     semver-minor-days: 7
     semver-patch-days: 3
     default-days: 10
+    include:
+      - "some-library/*"
     exclude:
-      - "@getyourguide*"
+      - "some-library/*"
 
 #
 # default settings for new "update" entities of a *specific* manifest type
@@ -47,8 +49,10 @@ update-overrides:
       semver-minor-days: 7
       semver-patch-days: 3
       default-days: 10
+      include:
+      - "some-library/*"
       exclude:
-        - "@getyourguide*"
+      - "some-library/*"
 
 #
 # default registries

--- a/dependabutler-sample.yml
+++ b/dependabutler-sample.yml
@@ -43,13 +43,12 @@ update-overrides:
       interval: weekly
       day: wednesday
     cooldown:
-      semver-major-days: 14
-      semver-minor-days: 3
-      semver-patch-days: 1
-      default-days: 30
+      semver-major-days: 21
+      semver-minor-days: 7
+      semver-patch-days: 3
+      default-days: 10
       exclude:
         - "@getyourguide*"
-        - "actions/*"
 
 #
 # default registries

--- a/dependabutler-sample.yml
+++ b/dependabutler-sample.yml
@@ -18,14 +18,6 @@ update-defaults:
     prefix: "[dependabutler] "
   open-pull-requests-limit: 10
   rebase-strategy: auto
-  cooldown:
-    semver-major-days: 21
-    semver-minor-days: 7
-    semver-patch-days: 3
-    default-days: 10
-    exclude:
-      - "internal-*"
-      - "@company/*"
 
 #
 # default settings for new "update" entities of a *specific* manifest type
@@ -43,14 +35,6 @@ update-overrides:
     schedule:
       interval: weekly
       day: wednesday
-    cooldown:
-      semver-major-days: 14
-      semver-minor-days: 3
-      semver-patch-days: 1
-      default-days: 30
-      exclude:
-        - "internal-*"
-        - "@company/*"
 
 #
 # default registries

--- a/dependabutler-sample.yml
+++ b/dependabutler-sample.yml
@@ -90,6 +90,7 @@ pull-request-parameters:
 # feature flags
 #
 stable-group-prefixes: true  # Ensures group names have numeric prefixes (01_, 02_, etc.)
+update-missing-cooldown-settings: true  # When true, adds missing cooldown settings to existing updates; when false, only adds cooldown to new repos/sections
 
 #
 # patterns for detecting manifest files

--- a/dependabutler-sample.yml
+++ b/dependabutler-sample.yml
@@ -18,6 +18,13 @@ update-defaults:
     prefix: "[dependabutler] "
   open-pull-requests-limit: 10
   rebase-strategy: auto
+  cooldown:
+    semver-major-days: 21
+    semver-minor-days: 7
+    semver-patch-days: 3
+    default-days: 10
+    exclude:
+      - "@getyourguide*"
 
 #
 # default settings for new "update" entities of a *specific* manifest type
@@ -35,6 +42,14 @@ update-overrides:
     schedule:
       interval: weekly
       day: wednesday
+    cooldown:
+      semver-major-days: 14
+      semver-minor-days: 3
+      semver-patch-days: 1
+      default-days: 30
+      exclude:
+        - "@getyourguide*"
+        - "actions/*"
 
 #
 # default registries

--- a/dependabutler-sample.yml
+++ b/dependabutler-sample.yml
@@ -23,10 +23,9 @@ update-defaults:
     semver-minor-days: 7
     semver-patch-days: 3
     default-days: 10
-    include:
-      - "some-library/*"
     exclude:
-      - "some-library/*"
+      - "internal-*"
+      - "@company/*"
 
 #
 # default settings for new "update" entities of a *specific* manifest type
@@ -45,14 +44,13 @@ update-overrides:
       interval: weekly
       day: wednesday
     cooldown:
-      semver-major-days: 21
-      semver-minor-days: 7
-      semver-patch-days: 3
-      default-days: 10
-      include:
-      - "some-library/*"
+      semver-major-days: 14
+      semver-minor-days: 3
+      semver-patch-days: 1
+      default-days: 30
       exclude:
-      - "some-library/*"
+        - "internal-*"
+        - "@company/*"
 
 #
 # default registries

--- a/dependabutler-sample.yml
+++ b/dependabutler-sample.yml
@@ -90,7 +90,7 @@ pull-request-parameters:
 # feature flags
 #
 stable-group-prefixes: true  # Ensures group names have numeric prefixes (01_, 02_, etc.)
-update-missing-cooldown-settings: true  # When true, adds missing cooldown settings to existing updates; when false, only adds cooldown to new repos/sections
+update-missing-cooldown-settings: false  # When true, adds missing cooldown settings to existing updates; when false, only adds cooldown to new repos/sections
 
 #
 # patterns for detecting manifest files

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -734,7 +734,6 @@ func addCooldownToExistingUpdate(update *Update, toolConfig ToolConfig) bool {
 	return modified
 }
 
-// addMissingTimingField adds a timing field value if it's missing (zero) and config has a value
 func addMissingTimingField(target *int, configValue int) bool {
 	if configValue != 0 && *target == 0 {
 		*target = configValue

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -404,9 +404,6 @@ func (config *DependabotConfig) ProcessManifest(manifestFile string, manifestTyp
 
 // createUpdateEntry creates a new update entry for a manifest file
 func createUpdateEntry(manifestType string, manifestPath string, toolConfig ToolConfig) Update {
-	// Use cooldown configuration from config file
-	cooldown := toolConfig.UpdateDefaults.Cooldown
-
 	update := Update{
 		PackageEcosystem:              manifestType,
 		Directory:                     manifestPath,
@@ -415,7 +412,7 @@ func createUpdateEntry(manifestType string, manifestPath string, toolConfig Tool
 		OpenPullRequestsLimit:         toolConfig.UpdateDefaults.OpenPullRequestsLimit,
 		RebaseStrategy:                toolConfig.UpdateDefaults.RebaseStrategy,
 		InsecureExternalCodeExecution: toolConfig.UpdateDefaults.InsecureExternalCodeExecution,
-		Cooldown:                      cooldown,
+		Cooldown:                      toolConfig.UpdateDefaults.Cooldown,
 	}
 	// apply override properties, if defined
 	if overrides, hasOverrides := toolConfig.UpdateOverrides[manifestType]; hasOverrides {

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -734,11 +734,14 @@ func addCooldownToExistingUpdate(update *Update, toolConfig ToolConfig) bool {
 		return false
 	}
 
-	// Preserve existing exclude/include lists, add default timing values
+	// Preserve existing exclude/include lists, or use config defaults if none exist
 	existingExclude := update.Cooldown.Exclude
 	existingInclude := update.Cooldown.Include
 	if len(existingExclude) == 0 {
-		existingExclude = []string{"@getyourguide*"}
+		existingExclude = toolConfig.UpdateDefaults.Cooldown.Exclude
+	}
+	if len(existingInclude) == 0 {
+		existingInclude = toolConfig.UpdateDefaults.Cooldown.Include
 	}
 
 	// Add timing configuration from config file while preserving user's exclude/include

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -747,8 +747,6 @@ func addCooldownToExistingUpdate(update *Update) bool {
 	// Preserve existing exclude/include lists, add default timing values
 	existingExclude := update.Cooldown.Exclude
 	existingInclude := update.Cooldown.Include
-	
-	// If no exclude list exists, use our default
 	if len(existingExclude) == 0 {
 		existingExclude = []string{"@getyourguide*"}
 	}

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -413,7 +413,7 @@ func createUpdateEntry(manifestType string, manifestPath string, toolConfig Tool
 		OpenPullRequestsLimit:         toolConfig.UpdateDefaults.OpenPullRequestsLimit,
 		RebaseStrategy:                toolConfig.UpdateDefaults.RebaseStrategy,
 		InsecureExternalCodeExecution: toolConfig.UpdateDefaults.InsecureExternalCodeExecution,
-		Cooldown:					   toolConfig.UpdateDefaults.Cooldown,
+		Cooldown:                      toolConfig.UpdateDefaults.Cooldown,
 	}
 	// apply override properties, if defined
 	if overrides, hasOverrides := toolConfig.UpdateOverrides[manifestType]; hasOverrides {
@@ -714,17 +714,16 @@ func ensureStableGroupPrefixes(update *Update) {
 
 // Adds cooldown configuration to existing updates that don't have it
 func addCooldownToExistingUpdate(update *Update, toolConfig ToolConfig) bool {
-	// Check if the flag is explicitly set to false
-	if toolConfig.UpdateMissingCooldownSettings != nil && !*toolConfig.UpdateMissingCooldownSettings {
+	if toolConfig.UpdateMissingCooldownSettings == nil || !*toolConfig.UpdateMissingCooldownSettings {
 		return false
 	}
-	
+
 	configCooldown := toolConfig.UpdateDefaults.Cooldown
-	
+
 	if !hasCooldownConfig(configCooldown) {
 		return false
 	}
-	
+
 	modified := false
 
 	// Add missing timing fields
@@ -760,7 +759,7 @@ func mergeStringLists(target *[]string, source []string) bool {
 }
 
 func hasCooldownConfig(cooldown Cooldown) bool {
-	return cooldown.SemverMajorDays != 0 || cooldown.SemverMinorDays != 0 || 
+	return cooldown.SemverMajorDays != 0 || cooldown.SemverMinorDays != 0 ||
 		cooldown.SemverPatchDays != 0 || cooldown.DefaultDays != 0 ||
 		len(cooldown.Include) > 0 || len(cooldown.Exclude) > 0
 }

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -533,10 +533,7 @@ func (config *DependabotConfig) UpdateConfig(manifests map[string]string, toolCo
 	// Fix existing updates, if necessary
 	for i := range config.Updates {
 		update := &config.Updates[i]
-		if fixExistingUpdateConfig(update) {
-			changeInfo.FixedUpdates = append(changeInfo.FixedUpdates, UpdateInfo{Type: update.PackageEcosystem, Directory: update.Directory, File: ""})
-		}
-		if addCooldownToExistingUpdate(update, toolConfig) {
+		if fixExistingUpdateConfig(update) || addCooldownToExistingUpdate(update, toolConfig) {
 			changeInfo.FixedUpdates = append(changeInfo.FixedUpdates, UpdateInfo{Type: update.PackageEcosystem, Directory: update.Directory, File: ""})
 		}
 	}

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -721,12 +721,6 @@ func ensureStableGroupPrefixes(update *Update) {
 	update.Groups = newGroups
 }
 
-func hasCooldownConfig(cooldown Cooldown) bool {
-	return cooldown.SemverMajorDays != 0 || cooldown.SemverMinorDays != 0 || 
-		cooldown.SemverPatchDays != 0 || cooldown.DefaultDays != 0 ||
-		len(cooldown.Include) > 0 || len(cooldown.Exclude) > 0
-}
-
 // Adds cooldown configuration to existing updates that don't have it
 func addCooldownToExistingUpdate(update *Update, toolConfig ToolConfig) bool {
 	configCooldown := toolConfig.UpdateDefaults.Cooldown
@@ -771,4 +765,10 @@ func mergeStringLists(target *[]string, source []string) bool {
 		}
 	}
 	return modified
+}
+
+func hasCooldownConfig(cooldown Cooldown) bool {
+	return cooldown.SemverMajorDays != 0 || cooldown.SemverMinorDays != 0 || 
+		cooldown.SemverPatchDays != 0 || cooldown.DefaultDays != 0 ||
+		len(cooldown.Include) > 0 || len(cooldown.Exclude) > 0
 }

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -735,14 +735,12 @@ func ensureStableGroupPrefixes(update *Update) {
 
 // addCooldownToExistingUpdate adds cooldown configuration to existing updates that don't have it
 func addCooldownToExistingUpdate(update *Update) bool {
-	// Check if any timing values are already configured
-	hasTimingConfig := update.Cooldown.SemverMajorDays != 0 || 
-	                   update.Cooldown.SemverMinorDays != 0 || 
-	                   update.Cooldown.SemverPatchDays != 0 || 
+	hasCooldonwConfig := update.Cooldown.SemverMajorDays != 0 && 
+	                   update.Cooldown.SemverMinorDays != 0 && 
+	                   update.Cooldown.SemverPatchDays != 0 && 
 	                   update.Cooldown.DefaultDays != 0
 
-	// If timing is already configured, don't modify anything
-	if hasTimingConfig {
+	if hasCooldonwConfig {
 		return false
 	}
 

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -721,18 +721,16 @@ func ensureStableGroupPrefixes(update *Update) {
 	update.Groups = newGroups
 }
 
-// hasCooldownConfig checks if a Cooldown struct has any configuration
 func hasCooldownConfig(cooldown Cooldown) bool {
 	return cooldown.SemverMajorDays != 0 || cooldown.SemverMinorDays != 0 || 
 		cooldown.SemverPatchDays != 0 || cooldown.DefaultDays != 0 ||
 		len(cooldown.Include) > 0 || len(cooldown.Exclude) > 0
 }
 
-// addCooldownToExistingUpdate adds cooldown configuration to existing updates that don't have it
+// Adds cooldown configuration to existing updates that don't have it
 func addCooldownToExistingUpdate(update *Update, toolConfig ToolConfig) bool {
 	configCooldown := toolConfig.UpdateDefaults.Cooldown
 	
-	// Skip if no cooldown configured
 	if !hasCooldownConfig(configCooldown) {
 		return false
 	}
@@ -764,7 +762,6 @@ func addCooldownToExistingUpdate(update *Update, toolConfig ToolConfig) bool {
 	return modified
 }
 
-// mergeStringLists adds items from source to target list if not already present
 func mergeStringLists(target *[]string, source []string) bool {
 	modified := false
 	for _, item := range source {

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -629,7 +629,7 @@ func TestEnsureStableGroupPrefixes(t *testing.T) {
 	}
 }
 
-func TestCooldownBasics(t *testing.T) {
+func TestCooldown(t *testing.T) {
 	// Test new manifest gets cooldown from config
 	config := DependabotConfig{}
 	toolConfig := ToolConfig{

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -628,3 +628,30 @@ func TestEnsureStableGroupPrefixes(t *testing.T) {
 		})
 	}
 }
+
+func TestCooldownBasics(t *testing.T) {
+	// Test new manifest gets cooldown
+	config := DependabotConfig{}
+	toolConfig := ToolConfig{}
+	changeInfo := ChangeInfo{}
+	config.ProcessManifest("package.json", "npm", toolConfig, &changeInfo, LoadFileContentDummy, LoadFileContentParameters{})
+	
+	if len(config.Updates) != 1 {
+		t.Errorf("Expected 1 update, got %d", len(config.Updates))
+		return
+	}
+	
+	cooldown := config.Updates[0].Cooldown
+	if cooldown.DefaultDays != 10 || cooldown.SemverMajorDays != 21 {
+		t.Errorf("Expected default cooldown values, got %+v", cooldown)
+	}
+	
+	// Test existing cooldown preservation
+	update := Update{Cooldown: Cooldown{SemverMajorDays: 15}}
+	if addCooldownToExistingUpdate(&update) {
+		t.Error("Should not modify existing cooldown")
+	}
+	if update.Cooldown.SemverMajorDays != 15 {
+		t.Error("Existing cooldown was modified")
+	}
+}

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -683,6 +683,13 @@ func TestCooldown(t *testing.T) {
 		t.Error("Missing DefaultDays should be added from config")
 	}
 	
+	// Test that empty config doesn't modify anything
+	emptyConfigUpdate := Update{Cooldown: Cooldown{SemverMajorDays: 5}}
+	emptyToolConfig := ToolConfig{}
+	if addCooldownToExistingUpdate(&emptyConfigUpdate, emptyToolConfig) {
+		t.Error("Should not modify anything when config has no cooldown")
+	}
+	
 	// Test include/exclude list merging
 	mergeUpdate := Update{Cooldown: Cooldown{
 		Exclude: []string{"@existing*"},


### PR DESCRIPTION
# Description
The cooldown is a recent addition to dependabot we have been waiting for long time.  
It's still in `beta`, but will be released soon.

- Adding support to `cooldown` in dependabutler. 
- Adding a flag: `update-missing-cooldown-settings`, to add missing cooldown properties to existing configs.

REF: https://github.com/dependabot/dependabot-core/issues/3651

### Example config
```yml
  cooldown:
    semver-major-days: 21
    semver-minor-days: 7
    semver-patch-days: 3
    default-days: 10
    exclude:
      - "@getyourguide*" # For internal dependencies we don't want to apply it.
      - ...              # We need to add here the internal name of gyg deps in other languages 

```