### PR TITLE
SEC-3358: Add deprecation support for reviewers field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,3 +92,7 @@ Initial version.
 ## v0.8.1
 
 - Fixed `update-missing-cooldown-settings` to also take into account potential override settings for the `cooldown` property.
+
+## v0.8.2
+
+- Added deprecation support for the `reviewers` field in `dependabot.yml` (will be removed by GitHub in May 2025)

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -550,6 +550,9 @@ func (config *DependabotConfig) UpdateConfig(manifests map[string]string, toolCo
 		}
 	}
 
+	// Remove deprecated reviewers field
+	removeDeprecatedReviewers(config)
+
 	// Check if there are unused registries to be removed
 	for name, registry := range config.Registries {
 		found := false
@@ -595,6 +598,21 @@ func fixNewUpdateConfig(update *Update, manifestType string) {
 	// remove "insecure-external-code-execution" if it is not allowed
 	if update.InsecureExternalCodeExecution != "" && manifestType != "bundler" && manifestType != "mix" && manifestType != "pip" {
 		update.InsecureExternalCodeExecution = ""
+	}
+	
+	// Warn about deprecated reviewers field
+	if len(update.Reviewers) > 0 {
+		log.Printf("WARNING: The 'reviewers' field is deprecated and will be removed by GitHub in May 2025. Use a CODEOWNERS file instead.")
+	}
+}
+
+// removeDeprecatedReviewers removes the deprecated reviewers field from all updates
+func removeDeprecatedReviewers(config *DependabotConfig) {
+	for i := range config.Updates {
+		if len(config.Updates[i].Reviewers) > 0 {
+			log.Printf("INFO: Removing deprecated 'reviewers' field from update %s", config.Updates[i].PackageEcosystem)
+			config.Updates[i].Reviewers = nil
+		}
 	}
 }
 

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -599,7 +599,7 @@ func fixNewUpdateConfig(update *Update, manifestType string) {
 	if update.InsecureExternalCodeExecution != "" && manifestType != "bundler" && manifestType != "mix" && manifestType != "pip" {
 		update.InsecureExternalCodeExecution = ""
 	}
-	
+
 	// Warn about deprecated reviewers field
 	if len(update.Reviewers) > 0 {
 		log.Printf("WARNING: The 'reviewers' field is deprecated and will be removed by GitHub in May 2025. Use a CODEOWNERS file instead.")


### PR DESCRIPTION
Removed `reviewers` field according to the following announcement from the Github team: https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/

Jira: SEC-3358

## How was this tested

Locally with `go test`

