### PR TITLE
Bump Go from 1.25.0 to 1.26.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/getyourguide/dependabutler
 
-go 1.25.0
+go 1.26.3
 
 require (
 	github.com/google/go-github/v50 v50.2.0


### PR DESCRIPTION
## Summary

- Upgrades `go.mod` from 1.25.0 to 1.26.3 (current stable)
- All tests pass, `go vet` clean, no deprecated API usage