### PR TITLE
Align CI Go version to 1.26

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,7 +13,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.25.x]
+        go-version: [1.26.x]
         platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -201,7 +201,7 @@ updates:
 		if err != nil {
 			t.Errorf("TestParseDependabotConfigWithDirectories() failed;\n  parsing error %v", err)
 		}
-		got := (string)(parsedConfig.ToYaml())
+		got := string(parsedConfig.ToYaml())
 		if tt.expected != got {
 			t.Errorf("TestParseDependabotConfigWithDirectories() failed;\n  expected \n%v\n  got      \n%v\n", tt.expected, got)
 		}


### PR DESCRIPTION
## What

`go.mod` was bumped to `1.26.3` in #115, but the CI workflow still pinned `1.25.x`. This updates the test matrix in `.github/workflows/go.yml` to `1.26.x` so CI matches the module version.

## Verification

Locally on go1.26.3: `go build ./...`, `go vet ./...`, and `go test ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)